### PR TITLE
Allow binding to enum properties.

### DIFF
--- a/Source/OmniXaml/ObjectAssembler/ValuePipeline.cs
+++ b/Source/OmniXaml/ObjectAssembler/ValuePipeline.cs
@@ -71,8 +71,12 @@ namespace OmniXaml.ObjectAssembler
 
             if (targetType.GetTypeInfo().IsEnum)
             {
-                converted = Enum.Parse(targetType, value.ToString());
-                return true;
+                // There's currently no non-generic Enum.TryParse. If it gets added, use that.
+                if (Enum.IsDefined(targetType, value.ToString()))
+                {
+                    converted = Enum.Parse(targetType, value.ToString());
+                    return true;
+                }
             }
 
             converted = null;


### PR DESCRIPTION
Previously if you tried to create a binding to an enum property, it would fail as OmniXAML would try to parse the binding as an enum value and fail with an exception.

This PR makes OmniXAML not throw an exception in this situation, however I'm not sure this is the correct way to do it.