### PR TITLE
Allow '#' in markup extensions.

### DIFF
--- a/Source/OmniXaml/Parsers/MarkupExtensions/MarkupExtensionParser.cs
+++ b/Source/OmniXaml/Parsers/MarkupExtensions/MarkupExtensionParser.cs
@@ -51,7 +51,7 @@ namespace OmniXaml.Parsers.MarkupExtensions
         private static readonly Parser<TreeNode> DirectValue = from value in ValidChars.Many()
                                                                select new StringNode(new string(value.ToArray()));
 
-        private static Parser<char> ValidChars => Parse.LetterOrDigit.Or(Parse.Chars(':', '.', '[', ']', '(', ')', '!', '$'));
+        private static Parser<char> ValidChars => Parse.LetterOrDigit.Or(Parse.Chars(':', '.', '[', ']', '(', ')', '!', '$', '#'));
 
         private static readonly Parser<TreeNode> StringValueNode = QuotedValue.Or(DirectValue);
 


### PR DESCRIPTION
Because i want to be able to bind to another control using syntax like `#controlname.Text`