### PR TITLE
Proof of concept fix for #57.

### DIFF
--- a/Source/Glass/StackingLinkedListMixin.cs
+++ b/Source/Glass/StackingLinkedListMixin.cs
@@ -1,19 +1,19 @@
 ﻿namespace Glass
 {
     using System;
+    using System.Collections.Generic;
 
     public static class StackingLinkedListMixin
     {
-        public static T ReverseLookup<T>(this StackingLinkedList<T> sll, Func<T, bool> lookupUntilPredicate) where T : class 
+        public static IEnumerable<LinkedListNode<T>> TraverseBackwards<T>(this StackingLinkedList<T> sll) where T : class 
         {
-            var currentNode = sll.Previous;
+            var currentNode = (LinkedListNode<T>)sll.Current;
             
-            while (currentNode != null && lookupUntilPredicate(currentNode.Value))
-            {                
+            while (currentNode != null)
+            {
+                yield return currentNode;
                 currentNode = currentNode.Previous;
             } 
-
-            return currentNode?.Value;
         }
     }
 }

--- a/Source/OmniXaml/ObjectAssembler/StateCommuter.cs
+++ b/Source/OmniXaml/ObjectAssembler/StateCommuter.cs
@@ -192,21 +192,9 @@ namespace OmniXaml.ObjectAssembler
 
         private INameScope LookupParentNamescope()
         {
-            var level = stack.ReverseLookup(l => !IsNameScope(l));
-            return level?.Instance as INameScope;
-        }
-
-        private static bool IsNameScope(Level level)
-        {
-            if (level.XamlType != null)
-            {
-                var xamlTypeSaysIsNameScope = level.XamlType.IsNameScope;
-                var instanceIsNameScope = level.Instance is INameScope;
-
-                return xamlTypeSaysIsNameScope && instanceIsNameScope;
-            }
-
-            return false;
+            return stack.TraverseBackwards()
+                .Select(x => x.Value.XamlType?.GetNamescope(x.Value.Instance))
+                .FirstOrDefault(x => x != null);
         }
 
         private void AddChildToHost()

--- a/Source/OmniXaml/Typing/XamlType.cs
+++ b/Source/OmniXaml/Typing/XamlType.cs
@@ -178,7 +178,10 @@ namespace OmniXaml.Typing
             return hasValidGetter && hasValidSetter && !isIndexer;
         }
 
-        public bool IsNameScope => LookupIsNamescope();
+        public virtual INameScope GetNamescope(object instance)
+        {
+            return this.UnderlyingType as INameScope;
+        }
 
         public XamlMember RuntimeNamePropertyMember
         {
@@ -201,11 +204,6 @@ namespace OmniXaml.Typing
 
                 return GetMember(runtimeNameProperty);
             }
-        }
-
-        protected virtual bool LookupIsNamescope()
-        {
-            return this.UnderlyingType is INameScope;
         }
     }
 }


### PR DESCRIPTION
Added XamlType.GetNameScope() to look up name scopes programatically.