### PR TITLE
Ignore dynamic assemblies.

### DIFF
--- a/Source/Glass/ReflectionExtensions.cs
+++ b/Source/Glass/ReflectionExtensions.cs
@@ -172,7 +172,9 @@
 
         public static IEnumerable<Type> AllExportedTypes(this IEnumerable<Assembly> assemblies)
         {
-            return assemblies.SelectMany(assembly => assembly.ExportedTypes);
+            return assemblies
+                .Where(assembly => !assembly.IsDynamic)
+                .SelectMany(assembly => assembly.ExportedTypes);
         }
 
         public static bool IsNullable(this Type type)


### PR DESCRIPTION
Cannot call ExportedTypes on a dynamic assembly so make sure these are filtered out first.