### PR TITLE
Fixes #89.

### DIFF
--- a/Source/OmniXaml/ObjectAssembler/Commands/ValueCommand.cs
+++ b/Source/OmniXaml/ObjectAssembler/Commands/ValueCommand.cs
@@ -20,6 +20,7 @@ namespace OmniXaml.ObjectAssembler.Commands
             {
                 case ValueProcessingMode.InitializationValue:
                     StateCommuter.Current.Instance = ValuePipeLine.ConvertValueIfNecessary(value, StateCommuter.Current.XamlType);
+                    StateCommuter.ValueProcessingMode = ValueProcessingMode.AssignToMember;
                     break;
 
                 case ValueProcessingMode.Key:

--- a/Source/Tests/OmniXaml.Tests/ObjectAssemblerTests.cs
+++ b/Source/Tests/OmniXaml.Tests/ObjectAssemblerTests.cs
@@ -459,5 +459,18 @@
             var listener = (TestListener)sut.LifecycleListener;
             CollectionAssert.AreEqual(expectedSequence, listener.InvocationOrder);
         }
+
+        [TestMethod]
+        public void MemberAfterInitalizationValue()
+        {
+            sut.Process(source.MemberAfterInitalizationValue);
+
+            var root = (RootObject)sut.Result;
+            var str = root.Collection[0];
+            var dummy = (DummyClass)root.Collection[1];
+
+            Assert.AreEqual("foo", str);
+            Assert.AreEqual(123, dummy.Number);
+        }
     }
 }

--- a/Source/Tests/OmniXaml.Tests/Resources/InstructionResources.cs
+++ b/Source/Tests/OmniXaml.Tests/Resources/InstructionResources.cs
@@ -1851,5 +1851,34 @@ namespace OmniXaml.Tests.Resources
                 };
             }            
         }
+
+        public IEnumerable<Instruction> MemberAfterInitalizationValue
+        {
+            get
+            {
+                return new List<Instruction>
+                {
+                    X.NamespacePrefixDeclaration(RootNs),
+                    X.StartObject<RootObject>(),
+                        X.StartMember<RootObject>(o => o.Collection),
+                            X.GetObject(),
+                                X.Items(),
+                                    X.StartObject<string>(),
+                                    X.Initialization(),
+                                    X.Value("foo"),
+                                    X.EndMember(),
+                                    X.EndObject(),
+                                    X.StartObject<DummyClass>(),
+                                    X.StartMember<DummyClass>(x => x.Number),
+                                    X.Value("123"),
+                                    X.EndMember(),
+                                    X.EndObject(),
+                                X.EndMember(),
+                            X.EndObject(),
+                        X.EndMember(),
+                    X.EndObject(),
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
StateCommuter.ValueProcessingMode wasn't being reset after InitializationValue in ValueCommand. Also includes a unit test for the issue.