### PR TITLE
Basic (non-attached) event support

### DIFF
--- a/Source/OmniXaml.Wpf/MemberValuePlugin.cs
+++ b/Source/OmniXaml.Wpf/MemberValuePlugin.cs
@@ -32,11 +32,7 @@ namespace OmniXaml.Wpf
             }
             else if (member.IsEvent)
             {
-                var topLevelInstance = valueContext.TopDownValueContext.StoredInstances.First().Instance;
-                var callback = topLevelInstance.GetType().GetTypeInfo().DeclaredMethods
-                    .FirstOrDefault(method => method.Name == (string)value);
-                member.Setter.Invoke(instance,
-                    new[] { callback.CreateDelegate(member.Setter.GetParameters()[0].ParameterType, topLevelInstance) });
+                base.AttachEventHandler(instance, (string)value, valueContext);
             }
             else
             {

--- a/Source/OmniXaml.Wpf/MemberValuePlugin.cs
+++ b/Source/OmniXaml.Wpf/MemberValuePlugin.cs
@@ -1,6 +1,7 @@
 namespace OmniXaml.Wpf
 {
     using System;
+    using System.Linq;
     using System.Reflection;
     using System.Windows;
     using System.Windows.Data;
@@ -28,6 +29,14 @@ namespace OmniXaml.Wpf
                 CommonValueConversion.TryConvert(value, xamlType, valueContext, out compatibleValue);
 
                 base.SetValue(instance, compatibleValue, valueContext);
+            }
+            else if (member.IsEvent)
+            {
+                var topLevelInstance = valueContext.TopDownValueContext.StoredInstances.First().Instance;
+                var callback = topLevelInstance.GetType().GetTypeInfo().DeclaredMethods
+                    .FirstOrDefault(method => method.Name == (string)value);
+                member.Setter.Invoke(instance,
+                    new[] { callback.CreateDelegate(member.Setter.GetParameters()[0].ParameterType, topLevelInstance) });
             }
             else
             {

--- a/Source/OmniXaml/Typing/AttachableMember.cs
+++ b/Source/OmniXaml/Typing/AttachableMember.cs
@@ -1,5 +1,6 @@
 namespace OmniXaml.Typing
 {
+    using System;
     using System.Reflection;
 
     public class AttachableMember : MutableMember
@@ -20,6 +21,8 @@ namespace OmniXaml.Typing
 
         public override bool IsAttachable => true;
         public override bool IsDirective => false;
+
+        public override bool IsEvent => false;
 
         public override MethodInfo Getter => getter;
 

--- a/Source/OmniXaml/Typing/Directive.cs
+++ b/Source/OmniXaml/Typing/Directive.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace OmniXaml.Typing
 {
     public class Directive : MemberBase
@@ -14,6 +16,7 @@ namespace OmniXaml.Typing
 
         public override bool IsDirective => true;
         public override bool IsAttachable => false;
+        public override bool IsEvent => false;
 
         public override string ToString()
         {

--- a/Source/OmniXaml/Typing/Member.cs
+++ b/Source/OmniXaml/Typing/Member.cs
@@ -1,5 +1,6 @@
 namespace OmniXaml.Typing
 {
+    using System;
     using System.Reflection;
     using Glass;
 
@@ -8,24 +9,63 @@ namespace OmniXaml.Typing
         public Member(string name, XamlType declaringType, ITypeRepository typeRepository, ITypeFeatureProvider featureProvider)
             : base(name, declaringType, typeRepository, featureProvider)
         {
+            IsEvent = CheckIfEvent();
             XamlType = LookupType();
         }
+
+        private bool CheckIfEvent()
+        {
+            var eventProperty = DeclaringType.UnderlyingType.GetRuntimeEvent(Name);
+            return eventProperty != null;
+        }
+
+        public override bool IsEvent { get; }
 
         public override bool IsAttachable => false;
 
         public override bool IsDirective => false;
 
-        public override MethodInfo Getter => DeclaringType.UnderlyingType.GetRuntimeProperty(Name).GetMethod;
-        public override MethodInfo Setter => DeclaringType.UnderlyingType.GetRuntimeProperty(Name).SetMethod;
+        public override MethodInfo Getter
+        {
+            get
+            {
+                if (IsEvent)
+                {
+                    return DeclaringType.UnderlyingType.GetRuntimeEvent(Name).RaiseMethod;
+                }
+                else
+                {
+                    return DeclaringType.UnderlyingType.GetRuntimeProperty(Name).GetMethod;
+                }
+            }
+        }
+
+        public override MethodInfo Setter
+        {
+            get
+            {
+                if (IsEvent)
+                {
+                    return DeclaringType.UnderlyingType.GetRuntimeEvent(Name).AddMethod;
+                }
+                else
+                {
+                    return DeclaringType.UnderlyingType.GetRuntimeProperty(Name).SetMethod;
+                }
+            }
+        }
 
         private XamlType LookupType()
         {
             var underlyingType = DeclaringType.UnderlyingType;
-            var property = underlyingType.GetRuntimeProperty(Name);
+            if (!IsEvent)
+            {
+                var property = underlyingType.GetRuntimeProperty(Name);
+                property.ThrowIfNull(() => new ParseException($"Cannot find a property or event named \"{Name}\" in the type {underlyingType}"));
+                return TypeRepository.GetByType(property.PropertyType);
+            }
 
-            property.ThrowIfNull(() => new ParseException($"Cannot find a property named \"{Name}\" in the type {underlyingType}") );
-
-            return TypeRepository.GetByType(property.PropertyType);
-        }              
+            return TypeRepository.GetByType(DeclaringType.UnderlyingType.GetRuntimeEvent(Name).EventHandlerType);
+        }
     }
 }

--- a/Source/OmniXaml/Typing/MemberBase.cs
+++ b/Source/OmniXaml/Typing/MemberBase.cs
@@ -4,8 +4,9 @@ namespace OmniXaml.Typing
     {
         public string Name { get; }
         public XamlType XamlType { get; protected set; }
-        public abstract bool IsDirective { get;  }
+        public abstract bool IsDirective { get; }
         public abstract bool IsAttachable { get; }
+        public abstract bool IsEvent { get; }
 
         protected MemberBase(string name)
         {
@@ -31,14 +32,14 @@ namespace OmniXaml.Typing
             {
                 return false;
             }
-            return Equals((MemberBase) obj);
+            return Equals((MemberBase)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return (Name.GetHashCode()*397) ^ XamlType.GetHashCode();
+                return (Name.GetHashCode() * 397) ^ XamlType.GetHashCode();
             }
         }
     }

--- a/Source/OmniXaml/Typing/MemberValuePlugin.cs
+++ b/Source/OmniXaml/Typing/MemberValuePlugin.cs
@@ -1,5 +1,6 @@
 namespace OmniXaml.Typing
 {
+    using System.Linq;
     using System.Reflection;
     using TypeConversion;
 
@@ -34,6 +35,15 @@ namespace OmniXaml.Typing
             {
                 member.Setter.Invoke(instance, new[] { value });
             }
+        }
+
+        protected virtual void AttachEventHandler(object instance, string eventName, IValueContext valueContext)
+        {
+            var topLevelInstance = valueContext.TopDownValueContext.StoredInstances.First().Instance;
+            var callback = topLevelInstance.GetType().GetRuntimeMethods()
+                .FirstOrDefault(method => method.Name == eventName);
+            member.Setter.Invoke(instance,
+                new[] { callback.CreateDelegate(member.Setter.GetParameters()[0].ParameterType, topLevelInstance) });
         }
 
         private MethodInfo ValueSetter

--- a/TestApplications/TestApplication/MainWindow.xaml
+++ b/TestApplications/TestApplication/MainWindow.xaml
@@ -46,7 +46,7 @@
             </Grid>
         </GroupBox>
         <ToolBar Grid.ColumnSpan="2" Grid.Row="1">
-            <Button Style="{StaticResource Style}" Content="Saludos cordiales" />
+            <Button Style="{StaticResource Style}" Content="Saludos cordiales" Click="Button_Click" />
         </ToolBar>
         
     </Grid>

--- a/TestApplications/TestApplication/MainWindow.xaml.cs
+++ b/TestApplications/TestApplication/MainWindow.xaml.cs
@@ -6,5 +6,8 @@
     [ViewToken("Main", typeof(MainWindow))]
     public class MainWindow : WpfWindow
     {
+        private void Button_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+        }
     }  
 }

--- a/Tests/OmniXaml.Wpf.Tests/GivenAXamlXmlLoader.cs
+++ b/Tests/OmniXaml.Wpf.Tests/GivenAXamlXmlLoader.cs
@@ -9,5 +9,11 @@ namespace OmniXaml.Wpf.Tests
             var p = new WpfLoader();
             return LoadMixin.FromString(p, xamlContent);
         }
+
+        protected object LoadXaml(string xamlContent, object rootInstance)
+        {
+            var p = new WpfLoader();
+            return LoadMixin.FromString(p, xamlContent, rootInstance);
+        }
     }
 }

--- a/Tests/OmniXaml.Wpf.Tests/LoadingTests.cs
+++ b/Tests/OmniXaml.Wpf.Tests/LoadingTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace OmniXaml.Wpf.Tests
 {
     using System.Windows;
+    using System.Windows.Automation.Peers;
+    using System.Windows.Automation.Provider;
     using System.Windows.Controls;
     using System.Windows.Media;
     using Xunit;
@@ -11,7 +13,7 @@
         [StaFact]
         public void Window()
         {
-            var windowType = typeof(Window);           
+            var windowType = typeof(Window);
 
             var actualInstance = LoadXaml(Resources.Window);
             Assert.IsType(windowType, actualInstance);
@@ -34,7 +36,7 @@
         [StaFact]
         public void DataTemplate()
         {
-            var visualTree = LoadXaml(Resources.DataTemplate);            
+            var visualTree = LoadXaml(Resources.DataTemplate);
         }
 
         [StaFact]
@@ -88,6 +90,24 @@
             Assert.Equal(0x80, color.R);
             Assert.Equal(0x80, color.G);
             Assert.Equal(0x80, color.B);
+        }
+
+        private class EventHandlingWindow : Window
+        {
+            public bool EventFired { get; private set; } = false;
+            private void TextChanged(object sender, RoutedEventArgs args)
+            {
+                EventFired = true;
+            }
+        }
+
+        [StaFact]
+        public void WindowWithEventHandler()
+        {
+            var visualTree = (EventHandlingWindow)LoadXaml(Resources.WindowWithEventHandler, new EventHandlingWindow());
+            var textBox = (TextBox)visualTree.Content;
+            textBox.Text = "New Text";
+            Assert.True(visualTree.EventFired);
         }
     }
 }

--- a/Tests/OmniXaml.Wpf.Tests/LoadingTests.cs
+++ b/Tests/OmniXaml.Wpf.Tests/LoadingTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace OmniXaml.Wpf.Tests
 {
     using System.Windows;
-    using System.Windows.Automation.Peers;
-    using System.Windows.Automation.Provider;
     using System.Windows.Controls;
     using System.Windows.Media;
     using Xunit;

--- a/Tests/OmniXaml.Wpf.Tests/OmniXaml.Wpf.Tests.csproj
+++ b/Tests/OmniXaml.Wpf.Tests/OmniXaml.Wpf.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Xaml" />
+    <Reference Include="UIAutomationProvider" />
     <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/Tests/OmniXaml.Wpf.Tests/OmniXaml.Wpf.Tests.csproj
+++ b/Tests/OmniXaml.Wpf.Tests/OmniXaml.Wpf.Tests.csproj
@@ -37,7 +37,6 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Xaml" />
-    <Reference Include="UIAutomationProvider" />
     <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/Tests/Xaml.Tests.Resources/Wpf.Designer.cs
+++ b/Tests/Xaml.Tests.Resources/Wpf.Designer.cs
@@ -323,5 +323,18 @@ namespace Xaml.Tests.Resources {
                 return ResourceManager.GetString("WindowWithContent", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;Window xmlns=&quot;http://schemas.microsoft.com/winfx/2006/xaml/presentation&quot;&gt;
+        ///  &lt;Window.Content&gt;
+        ///    &lt;Button Click=&quot;OnClicked&quot; /&gt;
+        ///  &lt;/Window.Content&gt;
+        ///&lt;/Window&gt;.
+        /// </summary>
+        public static string WindowWithEventHandler {
+            get {
+                return ResourceManager.GetString("WindowWithEventHandler", resourceCulture);
+            }
+        }
     }
 }

--- a/Tests/Xaml.Tests.Resources/Wpf.resx
+++ b/Tests/Xaml.Tests.Resources/Wpf.resx
@@ -166,4 +166,7 @@
   <data name="WindowWithContent" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>xaml\wpf\windowwithcontent.xaml;System.String, System.Runtime, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a;utf-8</value>
   </data>
+  <data name="WindowWithEventHandler" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>xaml\wpf\windowwitheventhandler.xaml;System.String, System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a;utf-8</value>
+  </data>
 </root>

--- a/Tests/Xaml.Tests.Resources/Xaml.Tests.Resources.csproj
+++ b/Tests/Xaml.Tests.Resources/Xaml.Tests.Resources.csproj
@@ -461,6 +461,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Xaml\Wpf\WindowWithEventHandler.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Tests/Xaml.Tests.Resources/Xaml/Wpf/WindowWithEventHandler.xaml
+++ b/Tests/Xaml.Tests.Resources/Xaml/Wpf/WindowWithEventHandler.xaml
@@ -1,0 +1,5 @@
+﻿<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <Window.Content>
+    <TextBox TextChanged="TextChanged" />
+  </Window.Content>
+</Window>


### PR DESCRIPTION
This PR adds support for subscribing to non-attached events with the event handler on the root element of the parsed string/document, as it is in WPF.